### PR TITLE
Update sort values in CollectionSystemManager.cpp

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -114,8 +114,8 @@ CollectionSystemManager::~CollectionSystemManager()
 
 bool systemSort(SystemData* sys1, SystemData* sys2)
 {
-	std::string name1 = Utils::String::toUpper(sys1->getName());
-	std::string name2 = Utils::String::toUpper(sys2->getName());
+	std::string name1 = Utils::String::toUpper(sys1->getFullName());
+	std::string name2 = Utils::String::toUpper(sys2->getFullName());
 	return name1.compare(name2) < 0;
 }
 
@@ -156,8 +156,8 @@ bool systemByManufacurerSort(SystemData* sys1, SystemData* sys2)
 		return false;
 
 	// Then by name
-	std::string name1 = Utils::String::toUpper(sys1->getName());
-	std::string name2 = Utils::String::toUpper(sys2->getName());
+	std::string name1 = Utils::String::toUpper(sys1->getFullName());
+	std::string name2 = Utils::String::toUpper(sys2->getFullName());
 	return name1.compare(name2) < 0;
 }
 
@@ -174,8 +174,8 @@ bool systemByReleaseDate(SystemData* sys1, SystemData* sys2)
 		return !sys2->isCollection();
 
 	// Then by name
-	std::string name1 = Utils::String::toUpper(sys1->getName());
-	std::string name2 = Utils::String::toUpper(sys2->getName());
+	std::string name1 = Utils::String::toUpper(sys1->getFullName());
+	std::string name2 = Utils::String::toUpper(sys2->getFullName());
 	return name1.compare(name2) < 0;
 }
 
@@ -192,8 +192,8 @@ bool systemByHardwareSort(SystemData* sys1, SystemData* sys2)
 		return mf1.compare(mf2) < 0;
 
 	// Then by name
-	std::string name1 = Utils::String::toUpper(sys1->getName());
-	std::string name2 = Utils::String::toUpper(sys2->getName());
+	std::string name1 = Utils::String::toUpper(sys1->getFullName());
+	std::string name2 = Utils::String::toUpper(sys2->getFullName());
 	return name1.compare(name2) < 0;
 }
 


### PR DESCRIPTION
Updated secondary sort value for Manfacturer, Release Date and Hardware to use fullname instead of name.  This will allow ES to sort consistently from the same metadata regardless of the sort option selected by a user.