### PR TITLE
Add Turbografx-CD/PCENGINE-CD like this for proper cheevos?

### DIFF
--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -76,7 +76,8 @@ const std::map<PlatformId, unsigned short> cheevosConsoleID
 	{ CHANNELF, 57 },
 	{ ZX_SPECTRUM, 59 },
 	{ NINTENDO_GAME_AND_WATCH, 60 },
-	{ NINTENDO_3DS, 62 }
+	{ NINTENDO_3DS, 62 },
+	{ TURBOGRAFX_CD, 63 }
 
 	// { VIC20, 34 },
 	//	{ CDI, 42 },


### PR DESCRIPTION
i can't test it, but maybe this should fix the issue, that the system will not show the retroachievment-symbol in the gamelist and left darkened in the main menu->retroachievements list, like the game would not be present on the device.
on the same regard MEGA_CD should be added because so far it only works with segacd, not megacd. (+achievements are not enabled per default for megacd)