### PR TITLE
Add the ability to scrape EasyRPG games through Screenscraper

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -127,6 +127,7 @@ namespace PlatformIds
 		{ "palm",					PALMOS },
 		{ "daphne",					DAPHNE },
 		{ "solarus",				SOLARUS },
+		{ "easyrpg",				EASYRPG },
 
 		{ "vic20",					VIC20 },
 		{ "c20",					VIC20 },

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -120,6 +120,7 @@ namespace PlatformIds
 		PALMOS,
 		DAPHNE,
 		SOLARUS,
+		EASYRPG,
 
 		VIC20,
 

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -134,6 +134,7 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ SPECTRAVIDEO, 218 },
 	{ PALMOS, 219 },
 	{ DAPHNE, 49 },
+	{ EASYRPG, 231 },
 	{ SOLARUS, 223 }	
 };
 


### PR DESCRIPTION
This commit adds the ability to scrape EasyRPG folders/games in ES.  Added a new platformID called "EASYRPG" and mapped it to screenscraper platform ID "231"

Credit and thank you to @Zowayix for identifying the fix needed.

Tested on my local device and confirmed working
![IMG_9286](https://user-images.githubusercontent.com/1454947/113478808-3a892a00-9459-11eb-8941-ea9037312044.jpg)
![IMG_9287](https://user-images.githubusercontent.com/1454947/113478809-3b21c080-9459-11eb-9619-751b3422afa2.jpg)
