### PR TITLE
Add TURBOGRAFX_CD / Remove TURBOGRAFX_16

### DIFF
--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -29,6 +29,7 @@ const std::map<PlatformId, unsigned short> cheevosConsoleID
 	{ GAME_BOY_ADVANCE, 5 },
 	{ GAME_BOY_COLOR, 6 },
 	{ NINTENDO_ENTERTAINMENT_SYSTEM, 7 },
+	{ TURBOGRAFX_16, 8 },
 	{ TURBOGRAFX_CD, 8 },
 	{ SEGA_CD, 9 },
 	{ SEGA_32X, 10 },

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -29,7 +29,7 @@ const std::map<PlatformId, unsigned short> cheevosConsoleID
 	{ GAME_BOY_ADVANCE, 5 },
 	{ GAME_BOY_COLOR, 6 },
 	{ NINTENDO_ENTERTAINMENT_SYSTEM, 7 },
-	{ TURBOGRAFX_16, 8 },
+	{ TURBOGRAFX_CD, 8 },
 	{ SEGA_CD, 9 },
 	{ SEGA_32X, 10 },
 	{ SEGA_MASTER_SYSTEM, 11 },


### PR DESCRIPTION
when trying to add TURBOGRAFX_CD, 8 - the build will fail because the 8 was assigned twice. so for testing i REMOVED the TURBOGRAFX_16 line, so only the CD line is there, this was mainly for testing if it would work at all. well as it turns out it will work for both systems now. why? i have no clue. it was tested first on a clean install where no pce games where even there when testing the pce-cd successfully then i just thought ok let's see what happens with the normal pce games now, then i added the roms, searched for cheevos and they were found. tried this too as update version on a running system where it also worked