### PR TITLE
Change 7zr to 7z to support .zip as well

### DIFF
--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -207,7 +207,7 @@ public:
 
 	virtual std::vector<std::string> getRetroachievementsSoundsList();
 	virtual std::vector<std::string> getShaderList(const std::string systemName = "");
-	virtual std::string getSevenZipCommand() { return "7zr"; }
+	virtual std::string getSevenZipCommand() { return "/usr/bin/7z"; }
 
 
 protected:


### PR DESCRIPTION
7zr does not support .zip files and yet ES uses this to unzip .zip files.
Changed to 7z.
Fixes achievement support in ES for some systems like snes
