### PR TITLE
Fixing gametime for >24h

### DIFF
--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -300,7 +300,7 @@ namespace Utils
 			char buf[256];
 
 			int h = 0, m = 0, s = 0;
-			h = (seconds / 3600) % 24;
+			h = (seconds / 3600);
 			m = (seconds / 60) % 60;
 			s = seconds % 60;
 			


### PR DESCRIPTION
It will now be shown correct when using md_gametime in the theme.
Showing hours (summarized) and minutes, no days.