### PR TITLE
Fix volume button on V stopping screensaver

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -241,7 +241,8 @@ void Window::input(InputConfig* config, Input input)
 	}
 
 	mTimeSinceLastInput = 0;
-	if (cancelScreenSaver())
+	// Only cancel screensave if a 'mapped' button is pushed (not volume, etc)
+	if (config->getMappedTo(input).size() > 0 && cancelScreenSaver())
 		return;
 
 	if (config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_g && SDL_GetModState() & KMOD_LCTRL) // && Settings::getInstance()->getBool("Debug"))


### PR DESCRIPTION
### Technical Details
This just stops any 'unmapped' button in Emulation Station from stopping the screensaver.  

In practice, the only buttons that are 'unmapped' Emulation Station are vol up/down on the V, so that allows you to adjust the volume on the V without stopping the screensaver.