### PR TITLE
Fix #451 - Screensaver kicking in upon waking from sleep mode

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -564,7 +564,22 @@ void Window::render()
 
 	unsigned int screensaverTime = (unsigned int)Settings::getInstance()->getInt("ScreenSaverTime");
 	if (mTimeSinceLastInput >= screensaverTime && screensaverTime != 0)
-		startScreenSaver();
+	{
+
+		// If we just woke up from sleep, treat that like a button press
+		// and restart the screensaver timer
+		auto lastResumeFile = "/run/.last_sleep_time";
+		if (Utils::FileSystem::exists(lastResumeFile))
+		{
+			mTimeSinceLastInput = 0;
+			Utils::FileSystem::removeFile(lastResumeFile);
+			return;
+		}
+		else 
+		{
+			startScreenSaver();
+		}
+	}
 
 	// Render notifications
 	if (!mRenderScreenSaver)


### PR DESCRIPTION
# Summary
Since the power button isn't treated like a 'real' button press in ES, sleep is difficult to detect.  This fix depends on a file being created when the device is put to sleep `/run/.last_sleep_time` - if that file exists, ES treats it like a button press and restarts the screensaver timer and deletes the file.

The file `/run/.last_sleep_time` must be created in the `pre` section of the sleep script (before sleep) as ES will always win a race condition of detecting if the file exists after sleep as it is already in a loop when `post` is run. 