### PR TITLE
Update : show version information before updating

### DIFF
--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -112,7 +112,12 @@ void GuiUpdate::threadPing()
 	{
 		std::vector<std::string> msgtbl;
 		if (ApiSystem::getInstance()->canUpdate(msgtbl))
+		{
+			if (msgtbl.size() == 1)
+				mUpdateVersion = msgtbl[0];
+
 			onUpdateAvailable();
+		}
 		else
 			onNoUpdateAvailable();
 	}
@@ -154,9 +159,15 @@ void GuiUpdate::update(int deltaTime)
 	switch (mState)
 	{
 		case 1:
-		
+		{
 			mState = 0;
-			window->pushGui(new GuiMsgBox(window, _("REALLY UPDATE?"), _("YES"), [this] 
+
+			std::string message = _("REALLY UPDATE?");
+
+			if (!mUpdateVersion.empty())
+				message = Utils::String::format(_("YOU ARE CURRENTLY USING VERSION : %s\r\nDO YOU WANT TO UPDATE TO VERSION : %s ?").c_str(), ApiSystem::getInstance()->getVersion().c_str(), mUpdateVersion.c_str()),
+
+			window->pushGui(new GuiMsgBox(window, message, _("YES"), [this]
 			{
 				mState = 2;
 				mLoading = true;
@@ -164,9 +175,9 @@ void GuiUpdate::update(int deltaTime)
 				mState = -1;
 				new ThreadedUpdater(mWindow);
 
-			}, _("NO"), [this]  { mState = -1; }));		
-		
-			break;
+			}, _("NO"), [this] { mState = -1; }));
+		}		
+		break;
 
 		case 3:
 		

--- a/es-app/src/guis/GuiUpdate.h
+++ b/es-app/src/guis/GuiUpdate.h
@@ -33,6 +33,8 @@ private:
     BusyComponent mBusyAnim;
     bool mLoading;
     int mState;
+	std::string mUpdateVersion;
+
     std::pair<std::string, int> mResult;
 
 	std::thread* mPingHandle;


### PR DESCRIPTION
Cherry-picked an upstream commit from emulec (technically batocera) which shows your current version and the version you'll be updating to before updating.

This will be useful if we roll out the 'beta' channel.